### PR TITLE
Week 2 Step 5-2: Use Datastore for storage and retrival of comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -43,7 +43,7 @@ public class DataServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Comment").addSort("timestamp", SortDirection.ASCENDING);
+    Query query = new Query("Comment").addSort("timestampMs", SortDirection.ASCENDING);
     PreparedQuery results = datastore.prepare(query);
 
     List<String> comments = new ArrayList<>();
@@ -64,10 +64,10 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("comment-text");
     if(comment != null){
-      long timestamp = System.currentTimeMillis();
+      long timestampMs = System.currentTimeMillis();
       Entity commentEn = new Entity("Comment");
       commentEn.setProperty("text",comment);
-      commentEn.setProperty("timestamp",timestamp);
+      commentEn.setProperty("timestampMs",timestampMs);
       datastore.put(commentEn);
     }
     response.sendRedirect("/index.html");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -56,10 +56,12 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("comment-text");
     if(comment != null){
-      comments.add(comment);
+      long timestamp = System.currentTimeMillis();
       Entity commentEn = new Entity("Comment");
       commentEn.setProperty("text",comment);
+      commentEn.setProperty("timestamp",timestamp);
       datastore.put(commentEn);
+      comments.add(comment);
     }
     response.sendRedirect("/index.html");
   }


### PR DESCRIPTION
DataServerlet no longer locally stores comments. All comment access is now done through DataStore so that comments are persistent across server restarts.