### PR TITLE
Attach User Data to Comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -23,13 +23,6 @@
       <version>1.9.59</version>
     </dependency>
 
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
-      <scope>provided</scope>
-    </dependency>
-
     <!--  Gson: Java to Json conversion -->
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -37,8 +30,21 @@
       <version>2.8.6</version>
       <scope>compile</scope>
     </dependency>
-  </dependencies>
 
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.12</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <!-- Provides `mvn package appengine:run` for local testing

--- a/portfolio/src/main/java/com/google/sps/entities/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/entities/Comment.java
@@ -1,10 +1,18 @@
 package com.google.sps.entities;
 
-import lombok.*;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 @Builder
 @Getter
 @Setter
+/**
+ * This is a POJO class meant to store all information required to display a datastore comment object
+ * from the DataServlet on one of the portfolio webpages
+ * Serialized intended to be done using Gson
+ */
 public class Comment {
   private String authorName;
   private String commentText;

--- a/portfolio/src/main/java/com/google/sps/entities/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/entities/Comment.java
@@ -1,0 +1,13 @@
+package com.google.sps.entities;
+
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+public class Comment {
+  private String authorName;
+  private String commentText;
+  private long timestampMs;
+
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -74,13 +74,17 @@ public class DataServlet extends HttpServlet {
    * Iff request has a non-null comment-text parameter,
    *   then create and store the parameter's String as a Datastore Comment Object
    * Always redirect to index.html
-   * If poster not logged in, return a HTTP 400 error code
+   * If poster not logged in, return a HTTP 403 error code as they must be logged in to comment
+   * If comment contains no text return a HTTP 400 error code as empty comments aren't allowed
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     if(userService.isUserLoggedIn()) {
-      String comment = request.getParameter("comment-text");
-      if (comment != null) {
+      String comment = Requests.getParameter(request, "comment-text", "");
+      if ("".equals(comment)) {
+        response.setStatus(400);
+      } else {
+        // User is logged in and posting a non-empty comment, store their requested comment
         String authorId = userService.getCurrentUser().getUserId();
         long timestampMs = System.currentTimeMillis();
         Entity commentEn = new Entity("Comment");
@@ -90,7 +94,7 @@ public class DataServlet extends HttpServlet {
         datastore.put(commentEn);
       }
     } else {
-      response.setStatus(400);
+      response.setStatus(403);
     }
     response.sendRedirect("/index.html");
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -24,6 +24,7 @@ import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
 import com.google.sps.entities.Comment;
+import com.google.sps.utils.Requests;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/portfolio/src/main/java/com/google/sps/servlets/LoginServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LoginServlet.java
@@ -2,6 +2,8 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.sps.utils.Requests;
+
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -14,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/login")
 public class LoginServlet extends HttpServlet {
   private static final UserService userService = UserServiceFactory.getUserService();
+
   /**
    * Redirects to a login page which forwards the user to the destination-url paramater after login
    * If destination-url is not given as a paramater its value defaults to the index
@@ -21,7 +24,7 @@ public class LoginServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String destinationURL = getDestinationUrl(request);
+    String destinationURL = Requests.getParameter(request, "destination-url", "/");
     String redirectURL;
     if(userService.isUserLoggedIn()) {
       redirectURL = destinationURL;
@@ -29,14 +32,5 @@ public class LoginServlet extends HttpServlet {
       redirectURL = userService.createLoginURL(destinationURL);
     }
     response.sendRedirect(redirectURL);
-  }
-
-  private String getDestinationUrl(HttpServletRequest request){
-    String destinationURL = request.getParameter("destination-url");
-    if(destinationURL == null){
-      return "/";
-    } else {
-      return destinationURL;
-    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/LogoutServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LogoutServlet.java
@@ -2,6 +2,8 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.sps.utils.Requests;
+
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -14,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/logout")
 public class LogoutServlet extends HttpServlet {
   private static final UserService userService = UserServiceFactory.getUserService();
+
   /**
    * Redirects to a page which logs out the user and redirects to the destination-url paramater
    * If destination-url is not given as a paramater its value defaults to the index
@@ -21,7 +24,7 @@ public class LogoutServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String destinationURL = getDestinationUrl(request);
+    String destinationURL = Requests.getParameter(request, "destination-url", "/");
     String redirectURL;
     if(userService.isUserLoggedIn()) {
       redirectURL = userService.createLogoutURL(destinationURL);
@@ -29,14 +32,5 @@ public class LogoutServlet extends HttpServlet {
       redirectURL = destinationURL;
     }
     response.sendRedirect(redirectURL);
-  }
-
-  private String getDestinationUrl(HttpServletRequest request){
-    String destinationURL = request.getParameter("destination-url");
-    if(destinationURL == null){
-      return "/";
-    } else {
-      return destinationURL;
-    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/UserInformationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserInformationServlet.java
@@ -118,7 +118,7 @@ public class UserInformationServlet extends HttpServlet {
   /**
    * Queries Datastore for a User Entity with the given Id, returns null if no match
    */
-  private Entity getUserEntity(String userId) {
+  public static Entity getUserEntity(String userId) {
     Query query =
         new Query("User")
             .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, userId));

--- a/portfolio/src/main/java/com/google/sps/utils/Requests.java
+++ b/portfolio/src/main/java/com/google/sps/utils/Requests.java
@@ -1,0 +1,36 @@
+package com.google.sps.utils;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Utility class to get information from HTTP Requests
+ */
+public class Requests {
+
+  /**
+   * Returns the value of a paramater from a HTTP request if present.
+   * If the request doesn't contain a value for the requested paramater, return a default value
+   */
+  public static String getParameter(HttpServletRequest request, String parameterName, String defaultValue){
+    if(hasParameterValue(request, parameterName)) {
+      return request.getParameter(parameterName);
+    } else {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Returns true iff the request contains the parameter parameterName, its value is ignored
+   */
+  public static boolean hasParameter(HttpServletRequest request, String parameterName) {
+    String parameterValue = request.getParameter(parameterName);
+    return parameterValue == null;
+  }
+
+  /**
+   * Returns true iff the request contains the parameterName and it has a nonempty value
+   */
+  public static boolean hasParameterValue(HttpServletRequest request, String parameterName) {
+    return hasParameter(request,parameterName) && !"".equals(request.getParameter(parameterName));
+  }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -39,7 +39,7 @@
           <input type="submit" value="Post Comment!"/>
         </form>
       </div>
-      <div class="comment-login" class="show-logged-out">
+      <div id="comment-login" class="show-logged-out">
         <a href="/login">Login</a>
         or
         <a href="/login?destination-url=/setUserInfo.html">Create Account</a>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -14,16 +14,16 @@
 
 /**
  * Fetches current user from UserInformationServlet and stores it in getCurrentUser.currentUser
- * If the user is not logged in the fetch will have a 400 response code, and the user stored will be null
+ * If the user is not logged in the fetch's status will not be ok, and the user stored will be null
  */
 async function initGetCurrentUser() {
   response = await fetch('/userInfo');
-  if(!response.ok){
-    getCurrentUser.currentUser = null;
-    getCurrentUser.initalized = true;
-  } else {
+  if(response.ok) {
     user = await response.json();
     getCurrentUser.currentUser = user;
+    getCurrentUser.initalized = true;
+  } else {
+    getCurrentUser.currentUser = null;
     getCurrentUser.initalized = true;
   }
 }
@@ -103,12 +103,24 @@ async function addComments() {
 /**
  * Adds one comment to the page
  */
-function addComment(commentText) {
-  commentElement = document.createElement("p");
-  commentElement.innerText = commentText;
+function addComment(comment) {
   const commentContainer = document.getElementById('comments');
-  commentContainer.appendChild(commentElement);
+  commentTextElement = document.createElement("p");
+  commentMetaDataElement = document.createElement("p");
+  commentMetaDataElement.className = "small-text";
+
+  commentMetaDataElement.innerText = getCommentMetaData(comment);
+  commentTextElement.innerText = comment.commentText;
+  commentContainer.appendChild(commentTextElement);
+  commentContainer.appendChild(commentMetaDataElement);
   commentContainer.appendChild(document.createElement("hr"));
+}
+
+function getCommentMetaData(comment) {
+  timestamp = new Date(comment.timestampMs);
+  authorName = comment.authorName;
+  return `${authorName}: ${timestamp.getMonth()}/${timestamp.getDate()}/${timestamp.getFullYear()} `
+      + `${timestamp.getHours()}:${timestamp.getMinutes()}`;
 }
 
 /**

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -31,3 +31,9 @@ body {
 .show-logged-out {
   display: none;
 }
+
+.small-text {
+  color: dimgrey;
+  font-size: smaller;
+  font-style: italic;
+}


### PR DESCRIPTION
What Changed:
Now DataStore Comment objects also hold the id of the user who created them.
DataServerlet posts now also requre the user to be logged in to accomplish this.
DataServerlet gets now return a list of JSON comment objects which hold their
timestamp and author name alongside their previously returned comment text.

Index.html comments now show comment text alongside metadata about the comment,
currently this includes the author's display name and the post date.

Concerns:
Datastore Comment objects aren't directly attached to their user objects,
each comment currently makes one query to datastore, this will become severly
inefficent as more comments are posted. Instead a single query should get all
of these user objects at once to reduce the number of queries made.